### PR TITLE
Allow token urls

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -44,6 +44,7 @@ class Scope(object):
 
 
 Target = namedtuple('Target', 'os_name os_code_name arch')
+github_url_pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
 
 
 def get_repositories_and_script_generating_key_files(
@@ -275,9 +276,7 @@ def get_short_arch(arch):
 
 
 def git_github_orgunit(url):
-    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-
-    if pattern.match(url) is None:
+    if github_url_pattern.match(url) is None:
         return None
     path = url[len(prefix):]
     index = path.index('/')
@@ -285,9 +284,7 @@ def git_github_orgunit(url):
 
 
 def get_github_project_url(url):
-    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-
-    if pattern.match(url) is None:
+    if github_url_pattern.match(url) is None:
         return None
     git_suffix = '.git'
     if not url.endswith(git_suffix):

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -14,7 +14,7 @@
 
 from collections import namedtuple
 import os
-
+import re
 
 class JobValidationError(Exception):
     """
@@ -274,8 +274,10 @@ def get_short_arch(arch):
 
 
 def git_github_orgunit(url):
-    prefix = 'https://github.com/'
-    if not url.startswith(prefix):
+    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern.match(url)
+
+    if pattern.match(url) is None:
         return None
     path = url[len(prefix):]
     index = path.index('/')
@@ -283,7 +285,10 @@ def git_github_orgunit(url):
 
 
 def get_github_project_url(url):
-    if not url.startswith('https://github.com/'):
+    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern.match(url)
+
+    if pattern.match(url) is None:
         return None
     git_suffix = '.git'
     if not url.endswith(git_suffix):

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -274,7 +274,7 @@ def get_short_arch(arch):
 
 
 def git_github_orgunit(url):
-    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
     pattern.match(url)
 
     if pattern.match(url) is None:
@@ -285,7 +285,7 @@ def git_github_orgunit(url):
 
 
 def get_github_project_url(url):
-    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
     pattern.match(url)
 
     if pattern.match(url) is None:

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -276,7 +276,6 @@ def get_short_arch(arch):
 
 def git_github_orgunit(url):
     pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-    pattern.match(url)
 
     if pattern.match(url) is None:
         return None
@@ -287,7 +286,6 @@ def git_github_orgunit(url):
 
 def get_github_project_url(url):
     pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-    pattern.match(url)
 
     if pattern.match(url) is None:
         return None

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -16,6 +16,7 @@ from collections import namedtuple
 import os
 import re
 
+
 class JobValidationError(Exception):
     """
     Indicates that the validation of a build job failed.


### PR DESCRIPTION
These build farm scripts are used (in part) for generating jobs. They currently assume that all URLs for the repos start with `http://github.com/`. This is not true for private repositories, as we have to affix a 40-character hex token to the front of the URL. I've tried cloning a private repo using this syntax, and the use of capital letters fails, hence the regex.

I've validate the regex [here](https://regex101.com/) and will try to find a way to test it within the build server before I submit the PR upstream. In the meantime, I also tested the important code via bpython:

```
>>> pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/"
>>> print pattern.match(url)  # Patten.match returns a Match object if the pattern is found 
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com"
>>> print pattern.match(url)  # Pattern.match returns None if no pattern is found
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/whatevER92994/aa"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f22722fa120>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5aaaaa@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abE5@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abg5@github.com/"
>>> print pattern.match(url)
None
>>> url = "https:/3dc7fb42354ce39edbc4f92b44786313cc53abf5@github.com/"
>>> print pattern.match(url)
None
>>> url = "http://3dc7fb42354ce39edbc4f92b44786313cc53abf5@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abf5github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abf5@github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://github.com"
>>> print pattern.match(url)
None
>>> url = "http://github.com/"
>>> print pattern.match(url)
None
>>> url = "https://@github.com"
>>> print pattern.match(url)
None
>>> url = "https://@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f22722fa120>
```

@locusrobotics/robot-software-team 

Please do not delete this branch once merged.