### PR TITLE
Check the latest branch

### DIFF
--- a/ros_buildfarm/bloom_status.py
+++ b/ros_buildfarm/bloom_status.py
@@ -1,0 +1,127 @@
+import os
+import re
+import time
+import yaml
+import requests
+import shutil
+from .templates import expand_template, get_template_path
+from github import Github, GithubException
+
+TOKEN_PATTERN = re.compile('https://([^@]*)@?github.com/.*git')
+ORG_PATTERN = re.compile('https://.*github.com/([^/]+)/.*git')
+
+
+def _download_yaml(url):
+    r = requests.get(url)
+    return yaml.load(r.text)
+
+
+def _get_distro_info(distros=None):
+    info = {}
+    main_url = os.environ['ROSDISTRO_INDEX_URL']
+    folder = os.path.split(main_url)[0]
+    D = _download_yaml(main_url)
+    for distro_name, distro_info in D['distributions'].items():
+        if distros is not None and distro_name not in distros:
+            continue
+        url_part = distro_info['distribution'][0]
+        new_url = os.path.join(folder, url_part)
+        info[distro_name] = _download_yaml(new_url)
+    if distros is not None:
+        remaining = set(distros) - set(info.keys())
+        for distro in remaining:
+            print('Warning! Distro "{}" not found.'.format(distro))
+    return info
+
+
+def _extract_token(distro_info):
+    for distro, distro_data in distro_info.items():
+        for name, d in distro_data['repositories'].items():
+            if 'source' not in d:
+                continue
+            m = TOKEN_PATTERN.match(d['source'].get('url', ''))
+            if m:
+                if len(m.group(1)):
+                    return m.group(1)
+
+
+def _get_package_info(distro_info):
+    packages = {}
+    for distro, distro_data in distro_info.items():
+        for name, d in distro_data['repositories'].items():
+            if name not in packages:
+                pkg = {}
+                packages[name] = pkg
+            else:
+                pkg = packages[name]
+            pkg[distro] = {}
+
+            if 'source' in d:
+                upstream = d['source'].get('version', None)
+                if upstream:
+                    pkg[distro]['upstream'] = upstream
+                m = ORG_PATTERN.match(d['source'].get('url', ''))
+                if m:
+                    pkg[distro]['org'] = m.group(1)
+
+            release = d.get('release', {}).get('version', None)
+            if release:
+                if '-' in release:
+                    release = release.partition('-')[0]
+                pkg[distro]['release'] = release
+    return packages
+
+
+def _get_package_status(g, name, branch_info):
+    if 'upstream' not in branch_info or 'org' not in branch_info:
+        return 'NO SOURCE'
+    elif 'release' not in branch_info:
+        return 'NO RELEASE'
+    try:
+        repo = g.get_repo(branch_info['org'] + '/' + name)
+        the_diff = repo.compare(branch_info['release'], branch_info['upstream'])
+        if len(the_diff.commits) > 0:
+            return 'CHANGED'
+        else:
+            return 'BLOOMED'
+    except GithubException as e:
+        print(e)
+        return 'BROKEN'
+
+
+def _query_package_statuses(g, package_info):
+    for pkg_name, info in package_info.items():
+        for distro, d_info in info.items():
+            status = _get_package_status(g, pkg_name, d_info)
+            d_info['status'] = status
+
+
+def build_bloom_status_page(distros=None, output_dir='.'):
+    start_time = time.time()
+    distro_info = _get_distro_info(distros)
+    token = _extract_token(distro_info)
+    package_info = _get_package_info(distro_info)
+    if token:
+        g = Github(token)
+    else:
+        g = Github()
+    _query_package_statuses(g, package_info)
+
+    data = {
+        'start_time': start_time,
+        'start_time_local_str': time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime(start_time)),
+        'packages': package_info,
+        'distros': list(distro_info.keys())
+    }
+
+    template_name = 'status/bloom_status_page.html.em'
+    html = expand_template(template_name, data)
+    output_filename = os.path.join(output_dir, 'bloom_status.html')
+    print("Generating bloom status page '%s':" % output_filename)
+    with open(output_filename, 'w') as h:
+        h.write(html)
+    for subfolder in ['css', 'js']:
+        dst = os.path.join(output_dir, subfolder)
+        if not os.path.exists(dst):
+            src = get_template_path(os.path.join('status', subfolder))
+            shutil.copytree(src, dst)

--- a/ros_buildfarm/git.py
+++ b/ros_buildfarm/git.py
@@ -23,7 +23,7 @@ from ros_buildfarm import __version__
 from ros_buildfarm.common import find_executable
 
 FALLBACK_REPOSITORY_URL = \
-    'https://github.com/ros-infrastructure/ros_buildfarm.git'
+    'https://github.com/locusrobotics/ros_buildfarm.git'
 
 
 def get_repository():

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -61,6 +61,9 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
+# magic https://github.com/docker/docker/issues/14203
+ENV DOCKER_FIX ' '
+
 @(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',
     dependencies=dependencies,

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -62,7 +62,7 @@ RUN echo "@today_str"
 ))@
 
 # magic https://github.com/docker/docker/issues/14203
-ENV DOCKER_FIX ' '
+#ENV DOCKER_FIX ' '
 
 @(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -62,7 +62,7 @@ RUN echo "@today_str"
 ))@
 
 # magic https://github.com/docker/docker/issues/14203
-#ENV DOCKER_FIX ' '
+ENV DOCKER_FIX ' '
 
 @(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',

--- a/ros_buildfarm/templates/status/bloom_status_job.xml.em
+++ b/ros_buildfarm/templates/status/bloom_status_job.xml.em
@@ -1,0 +1,97 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=100,
+    num_to_keep=100,
+))@
+@(SNIPPET(
+    'property_job-priority',
+    priority=20,
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
+    relative_target_dir='ros_buildfarm',
+    refspec=None,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>slave_on_master</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+@(SNIPPET(
+    'trigger_timer',
+    spec='0 * * * *',
+))@
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_shell_docker-info',
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'rm -fr $WORKSPACE/docker_generate_bloom_page',
+        'mkdir -p $WORKSPACE/docker_generate_bloom_page',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generate_bloom_page/docker.cid > $WORKSPACE/docker_generate_bloom_page/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# generate Dockerfile, build and run it',
+        '# generating the bloom status page',
+        'echo "# BEGIN SECTION: Generate Dockerfile - bloom status page"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/status/run_bloom_status_page_job.py' +
+        ' --dockerfile-dir $WORKSPACE/docker_generate_bloom_page' +
+        ' --rosdistro ' + rosdistro_index_url,
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - bloom status page"',
+        'cd $WORKSPACE/docker_generate_bloom_page',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t bloom_page_generation .',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - bloom status page"',
+        'rm -fr $WORKSPACE/bloom_status',
+        'mkdir -p $WORKSPACE/bloom_status',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_generate_bloom_page/docker.cid' +
+        ' --net=host' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v $WORKSPACE/bloom_status:/tmp/bloom_status' +
+        ' bloom_page_generation',
+        'echo "# END SECTION"',
+    ]),
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_publish-over-ssh',
+    config_name='status_page',
+    remote_directory='',
+    source_files=['bloom_status/**'],
+    remove_prefix='bloom_status',
+))@
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>

--- a/ros_buildfarm/templates/status/bloom_status_page.html.em
+++ b/ros_buildfarm/templates/status/bloom_status_page.html.em
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Bloom Status Page - @start_time_local_str</title>
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+
+  <script type="text/javascript" src="js/moment.min.js"></script>
+  <script type="text/javascript" src="js/zepto.min.js"></script>
+  <script type="text/javascript">
+    window.META_COLUMNS = 5;
+  </script>
+  <script type="text/javascript" src="js/setup.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="css/status_page.css" />
+</head>
+<body>
+  <script type="text/javascript">
+    window.body_ready_with_age(moment.duration(moment() - moment("@start_time", "X")));
+  </script>
+  <div class="top logo search">
+    <h1><img src="http://wiki.ros.org/custom/images/ros_org.png" alt="ROS.org" width="150" height="32" /></h1>
+    <h2>Bloom Status Page</h2>
+    <p>Quick filter:
+      <a href="?q=" title="Show all packages">*</a>,
+      <a href="?q=NO SOURCE">NO SOURCE</a>,
+      <a href="?q=NO RELEASE">NO RELEASE</a>,
+      <a href="?q=CHANGED">CHANGED</a>,
+      <a href="?q=BLOOMED">BLOOMED</a>,
+      <a href="?q=BROKEN">BROKEN</a>
+    </p>
+    <form action="?">
+      <input type="text" name="q" id="q" title="A query string can contain multiple '+' separated parts which must all be satisfied. Each part can also be a RegExp (e.g. to combine two parts with 'OR': 'foo|bar'), but can't contain '+'." />
+      <p id="search-count"></p>
+    </form>
+  </div>
+  <div class="top age">
+    <p>This should show the age of the page...</p>
+  </div>
+  <table>
+    <caption></caption>
+    <thead>
+      <tr>
+        <th class="sortable"><div>Name</div></th>
+@[for distro in distros]@
+        <th class="sortable"><div>@distro<br/>Status</div></th>
+        <th><div>@distro<br/>Version</div></th>
+@[end for]@
+      </tr>
+    </thead>
+    <tbody>
+      <script type="text/javascript">window.tbody_ready();</script>
+
+@[for pkg in sorted(packages)]@
+<tr><th><div>@pkg</div></th>
+@[for distro in distros]@
+        <td><div>@(packages[pkg].get(distro, {}).get('status', ''))</div></td>
+        <td><div>@(packages[pkg].get(distro, {}).get('release', ''))</div></td>
+@[end for]@
+</tr>
+@[end for]@
+
+    </tbody>
+  </table>
+  <script type="text/javascript">window.body_done();</script>
+</body>
+</html>

--- a/ros_buildfarm/templates/status/bloom_status_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/bloom_status_page_task.Dockerfile.em
@@ -1,0 +1,41 @@
+# generated from @template_name
+
+FROM ubuntu:xenial
+
+VOLUME ["/var/cache/apt/archives"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
+))@
+
+RUN useradd -u @uid -m buildfarm
+
+@(TEMPLATE(
+    'snippet/add_wrapper_scripts.Dockerfile.em',
+    wrapper_scripts=wrapper_scripts,
+))@
+
+# automatic invalidation once every day
+RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name='ubuntu',
+    os_code_name='xenial',
+))@
+
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-pip python3-yaml python3-empy
+RUN pip3 install pygithub requests
+
+USER buildfarm
+ENTRYPOINT ["sh", "-c"]
+@{
+cmd = \
+    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH ROSDISTRO_INDEX_URL=' + rosdistro_index_url + ' python3 -u' + \
+    ' /tmp/ros_buildfarm/scripts/status/build_bloom_status_page.py' + \
+    ' --output-dir /tmp/bloom_status'
+}@
+CMD ["@cmd"]

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -135,6 +135,7 @@ def main(argv=sys.argv[1:]):
                 dry_run=not args.commit)
         generate_blocked_releases_page_job(
             args.config_url, ros_distro_name, dry_run=not args.commit)
+        generate_bloom_status_job(args.config_url, dry_run=not args.commit)
 
 
 def generate_check_slaves_job(config_url, dry_run=False):
@@ -289,6 +290,14 @@ def generate_doc_metadata_job(
         cmd.append('--dry-run')
     _check_call(cmd)
 
+def generate_bloom_status_job(config_url, dry_run=False):
+    cmd = [
+        _resolve_script('status', 'generate_bloom_status_job.py'),
+        config_url,
+    ]
+    if dry_run:
+        cmd.append('--dry-run')
+    _check_call(cmd)
 
 def _resolve_script(subfolder, filename):
     basepath = os.path.abspath(os.path.dirname(__file__))

--- a/scripts/status/build_bloom_status_page.py
+++ b/scripts/status/build_bloom_status_page.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_output_dir
+from ros_buildfarm.bloom_status import build_bloom_status_page
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'build_bloom_status_page' job")
+    add_argument_output_dir(parser)
+    args = parser.parse_args(argv)
+
+    return build_bloom_status_page(output_dir=args.output_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status/generate_bloom_status_job.py
+++ b/scripts/status/generate_bloom_status_job.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright 2014-2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.config import get_index
+from ros_buildfarm.git import get_repository
+from ros_buildfarm.jenkins import configure_job
+from ros_buildfarm.jenkins import configure_management_view
+from ros_buildfarm.jenkins import connect
+from ros_buildfarm.templates import expand_template
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate the 'bloom_status' job on Jenkins")
+    add_argument_config_url(parser)
+    add_argument_dry_run(parser)
+    args = parser.parse_args(argv)
+
+    config = get_index(args.config_url)
+    job_config = get_job_config(args, config)
+
+    jenkins = connect(config.jenkins_url)
+
+    configure_management_view(jenkins, dry_run=args.dry_run)
+
+    job_name = 'bloom_status'
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
+
+
+def get_job_config(args, config):
+    template_name = 'status/bloom_status_job.xml.em'
+    job_data = {
+        'ros_buildfarm_repository': get_repository(),
+        'rosdistro_index_url': config.rosdistro_index_url,
+    }
+    job_config = expand_template(template_name, job_data)
+    return job_config
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status/run_bloom_status_page_job.py
+++ b/scripts/status/run_bloom_status_page_job.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_rosdistro_index_url
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'bloom_status_page' job")
+    add_argument_dockerfile_dir(parser)
+    add_argument_rosdistro_index_url(parser, required=True)
+    args = parser.parse_args(argv)
+
+    data = copy.deepcopy(args.__dict__)
+    data.update({
+        'uid': get_user_id(),
+    })
+    create_dockerfile(
+        'status/bloom_status_page_task.Dockerfile.em',
+        data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Strap in. Its a doozy. 

Our bloom status page shows the wrong version of some forked packages because the [version number in rosdistro](http://gitlab.locusbots.io/locusrobotics/rosdistro/blob/68a5394387a4697075ba84f4da26bfc98511f781/kinetic/distribution.yaml#L1118) does not match the [unique names for our forked releases](https://github.com/locusrobotics/navigation/releases). This is caused by [the release_tag being set to ask](http://gitlab.locusbots.io/locusrobotics/navigation-release/blob/02ca9aa342a9eae2efb7db7240841ce997c243f0/tracks.yaml#L21) in the release repository, as per our [release instruction](https://locusrobotics.atlassian.net/wiki/spaces/RST/pages/16473998/Releasing+Internal+Packages)

(in other cases, the [version number](http://gitlab.locusbots.io/locusrobotics/rosdistro/blob/master/kinetic/distribution.yaml#L899) matches the [tag name](https://github.com/locusrobotics/locus_navigation/releases) minus the last `-0`)

So now when get information about each repository, we
 * [open up the `tracks.yaml` from the release repo](https://github.com/locusrobotics/ros_buildfarm/commit/c321f12ca07780128440484e51581e1129a7b181#diff-e632a08564d6321cce85bdbd603f79abR148)
 * [if the tag is set to `:{ask}`, flag it](https://github.com/locusrobotics/ros_buildfarm/commit/c321f12ca07780128440484e51581e1129a7b181#diff-e632a08564d6321cce85bdbd603f79abR155)
 * [if the repo is flagged, set the release tag to whatever the latest tag is](https://github.com/locusrobotics/ros_buildfarm/commit/c321f12ca07780128440484e51581e1129a7b181#diff-e632a08564d6321cce85bdbd603f79abR170)

Of course, as detailed in the code, the process of figuring out the latest tag is non-trivial. 